### PR TITLE
clone sgx ssl openssl 1.1.0

### DIFF
--- a/src/CryptoLib/sgxssl/build.sh
+++ b/src/CryptoLib/sgxssl/build.sh
@@ -23,7 +23,7 @@ fi
 
 # get a fresh copy of sgx-ssl
 rm -rf intel-sgx-ssl
-git clone https://github.com/intel/intel-sgx-ssl.git || exit 1
+git clone --branch openssl_1.1.0 https://github.com/intel/intel-sgx-ssl.git || exit 1
 
 # cleanup old builds
 rm -rf $PROJECT_ROOT/lib64/*


### PR DESCRIPTION
sgxssl head is now only for openssl 1.1.1, changed to clone the 1.1.0 branch

Signed-off-by: Ishai Nadler <ishai.nadler@intel.com>